### PR TITLE
Makefile libdir variable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,6 @@
 SUBDIRS = ptex utils tests
+INSTALLDIR = ../../install
+LIBDIR = lib
 
 .PHONY: subdirs $(SUBDIRS)
 
@@ -10,4 +12,4 @@ clean:
 	done
 
 $(SUBDIRS):
-	$(MAKE) -C $@
+	$(MAKE) -C $@ INSTALLDIR=$(INSTALLDIR) LIBDIR=$(LIBDIR)

--- a/src/ptex/Makefile
+++ b/src/ptex/Makefile
@@ -38,9 +38,10 @@ SRCS = \
 OBJECTS = $(patsubst %.cpp,%.o,$(SRCS))
 
 INSTALLDIR = ../../install
+LIBDIR = lib
 
 INSTALL = \
-	lib/libPtex.a \
+	$(LIBDIR)/libPtex.a \
 	include/Ptexture.h \
 	include/PtexHalf.h \
 	include/PtexInt.h \
@@ -50,10 +51,10 @@ ALL = libPtex.a
 
 ifndef PTEX_STATIC
 ALL += libPtex.so
-INSTALL += lib/libPtex.so
+INSTALL += $(LIBDIR)/libPtex.so
 endif
 
-$(INSTALLDIR)/lib/% : %
+$(INSTALLDIR)/$(LIBDIR)/% : %
 	@ mkdir -p $(@D)
 	cp $^ $@
 


### PR DESCRIPTION
Here are the changes to allow a configurable library subdirectory.  Let me know if there's anything to redo.

The only concerning part is this snippet in src/Makefile:

```
$(SUBDIRS):
    $(MAKE) -C $@ INSTALLDIR=$(INSTALLDIR) LIBDIR=$(LIBDIR)
```

We'd have to remember to expand that command line every time a new variable is introduced.
It shouldn't matter in practice, though, since I don't foresee this changing very often.
