### PR TITLE
Fix for Win32 build

### DIFF
--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -1,3 +1,7 @@
+if (WIN32)
+  add_definitions ( /DPTEX_EXPORTS )
+endif (WIN32)
+
 set(SRCS
     PtexCache.cpp
     PtexFilters.cpp


### PR DESCRIPTION
Add a conditional ADD_DEFINITIONS for WIN32 to export the symbols for correct linkage.
