### PR TITLE
Checking face-adjacency consistency

### DIFF
--- a/src/utils/ptxinfo.cpp
+++ b/src/utils/ptxinfo.cpp
@@ -235,11 +235,10 @@ int CheckAdjacency(PtexTexture* tx)
                     continue;
                 
                 // subface case
-                if (finfo.isSubface()) {
-                    if (e==0 and oppfid == finfo.adjface(1))
-                        continue;
-                    else if (e==3 and oppfid == finfo.adjface(2))
-                        continue;
+                if (finfo.isSubface() && !adjf.isSubface()) {
+                    // neighbor face might be pointing to "other" subface
+                    if (oppfid == finfo.adjface((e+1)%4)) 
+                        continue;                
                 }
                 
                 std::cerr << "face " << fid << " edge " << e 


### PR DESCRIPTION
Adding a -c flag to ptxinfo to check the consistency of the face adjacency data. Errors found are listed in the terminal console.
