### PR TITLE
Rotate texture values when filtering for tangent-space textures

### DIFF
--- a/src/ptex/PtexIO.h
+++ b/src/ptex/PtexIO.h
@@ -67,6 +67,7 @@ struct PtexIO : public Ptex {
 	uint64_t lmddatasize;
 	uint64_t editdatasize;
 	uint64_t editdatapos;
+	EdgeFilterMode edgefiltermode;
     };
     struct LevelInfo {
 	uint64_t leveldatasize;

--- a/src/ptex/PtexReader.cpp
+++ b/src/ptex/PtexReader.cpp
@@ -93,6 +93,12 @@ bool PtexReader::open(const char* path, Ptex::String& error)
     memset(&_extheader, 0, sizeof(_extheader));
     readBlock(&_extheader, PtexUtils::min(uint32_t(ExtHeaderSize), _header.extheadersize));
 
+    // file version 1.4 added edgefiltermode into ExtHeader
+    // previous versions have behavior equivalent to edgefiltermode = efm_none
+    if (_header.version == 1 && _header.minorversion < 4) {
+	_extheader.edgefiltermode = efm_none;
+    }
+
     // compute offsets of various blocks
     FilePos pos = tell();
     _faceinfopos = pos;   pos += _header.faceinfosize;

--- a/src/ptex/PtexReader.h
+++ b/src/ptex/PtexReader.h
@@ -82,6 +82,7 @@ public:
     virtual Ptex::DataType dataType() { return DataType(_header.datatype); }
     virtual Ptex::BorderMode uBorderMode() { return BorderMode(_extheader.ubordermode); }
     virtual Ptex::BorderMode vBorderMode() { return BorderMode(_extheader.vbordermode); }
+    virtual Ptex::EdgeFilterMode edgeFilterMode() { return EdgeFilterMode(_extheader.edgefiltermode); }
     virtual int alphaChannel() { return _header.alphachan; }
     virtual int numChannels() { return _header.nchannels; }
     virtual int numFaces() { return _header.nfaces; }

--- a/src/ptex/PtexSeparableFilter.cpp
+++ b/src/ptex/PtexSeparableFilter.cpp
@@ -54,6 +54,7 @@ void PtexSeparableFilter::eval(float* result, int firstChan, int nChannels,
     if (faceid < 0 || faceid >= _tx->numFaces()) return;
     _ntxchan = _tx->numChannels();
     _dt = _tx->dataType();
+    _efm = _tx->edgeFilterMode();
     _firstChanOffset = firstChan*DataSize(_dt);
     _nchan = PtexUtils::min(nChannels, _ntxchan-firstChan);
 
@@ -354,7 +355,7 @@ void PtexSeparableFilter::apply(PtexSeparableKernel& k, int faceid, const Ptex::
     if (!dh) return;
 
     if (dh->isConstant()) {
-	k.applyConst(_result, (char*)dh->getData()+_firstChanOffset, _dt, _nchan);
+	k.applyConst(_result, (char*)dh->getData()+_firstChanOffset, _dt, _efm, _nchan);
     }
     else if (dh->isTiled()) {
 	Ptex::Res tileres = dh->tileRes();
@@ -376,14 +377,14 @@ void PtexSeparableFilter::apply(PtexSeparableKernel& k, int faceid, const Ptex::
 		PtexPtr<PtexFaceData> th ( dh->getTile(tilev * ntilesu + tileu) );
 		if (th) {
 		    if (th->isConstant())
-			kt.applyConst(_result, (char*)th->getData()+_firstChanOffset, _dt, _nchan);
+			kt.applyConst(_result, (char*)th->getData()+_firstChanOffset, _dt, _efm, _nchan);
 		    else
-			kt.apply(_result, (char*)th->getData()+_firstChanOffset, _dt, _nchan, _ntxchan);
+			kt.apply(_result, (char*)th->getData()+_firstChanOffset, _dt, _efm, _nchan, _ntxchan);
 		}
 	    }
 	}
     }
     else {
-	k.apply(_result, (char*)dh->getData()+_firstChanOffset, _dt, _nchan, _ntxchan);
+	k.apply(_result, (char*)dh->getData()+_firstChanOffset, _dt, _efm, _nchan, _ntxchan);
     }
 }

--- a/src/ptex/PtexSeparableFilter.h
+++ b/src/ptex/PtexSeparableFilter.h
@@ -53,7 +53,8 @@ class PtexSeparableFilter : public PtexFilter, public Ptex
     PtexSeparableFilter(PtexTexture* tx, const PtexFilter::Options& opts ) :
 	_tx(tx), _options(opts), _result(0), _weight(0), 
 	_firstChanOffset(0), _nchan(0), _ntxchan(0),
-	_dt((DataType)0), _uMode(tx->uBorderMode()), _vMode(tx->vBorderMode()) {}
+	_dt((DataType)0), _uMode(tx->uBorderMode()), _vMode(tx->vBorderMode()), 
+        _efm(tx->edgeFilterMode()) {}
     virtual ~PtexSeparableFilter() {}
 
     virtual void buildKernel(PtexSeparableKernel& k, float u, float v, float uw, float vw,
@@ -75,6 +76,7 @@ class PtexSeparableFilter : public PtexFilter, public Ptex
     int _ntxchan;		// number of channels in texture
     DataType _dt;		// data type of texture
     BorderMode _uMode, _vMode;	// border modes (clamp,black,periodic)
+    EdgeFilterMode _efm; // edge filter mode (rotate when kernel is rotated or not)
 };
 
 #endif

--- a/src/ptex/PtexSeparableKernel.cpp
+++ b/src/ptex/PtexSeparableKernel.cpp
@@ -38,6 +38,87 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include "PtexSeparableKernel.h"
 
 namespace {
+
+    // Vector Accumulate with a rotation function for the first 2 channels
+    // (to rotate based on rotation of face)
+    template<typename T, int n>
+    struct VecAccumTV {
+	void operator()(float* dst, const T* val, float weight,
+	    void (*rotFn)(float*, const T*, float))
+	{
+	    rotFn(dst, val, weight);
+	    PtexUtils::VecAccum<T,n-2>()(dst+2, val+2, weight);
+	}
+    };
+
+    // for nchan=1,0, don't rotate
+    template<typename T>
+    struct VecAccumTV<T,1> {
+	void operator()(float* dst, const T* val, float weight,
+	    void (*)(float*, const T*, float))
+	{
+	    PtexUtils::VecAccum<T,1>()(dst, val, weight);
+	}
+    };
+    template<typename T>
+    struct VecAccumTV<T,0> {
+	void operator()(float* dst, const T* val, float weight,
+	    void (*)(float*, const T*, float))
+	{
+	    PtexUtils::VecAccum<T,0>()(dst, val, weight);
+	}
+    };
+
+    // generic rotated vec accum.
+    template<typename T>
+    struct VecAccumNTV {
+	void operator()(float* dst, const T* val, int nchan, float weight,
+	    void (*rotFn)(float*, const T*, float))
+	{
+	    if (nchan >= 2)
+	    {
+		rotFn(dst, val, weight);
+		PtexUtils::VecAccumN<T>()(dst+2, val+2, nchan-2, weight);
+	    }
+	    else {
+		PtexUtils::VecAccumN<T>()(dst, val, nchan, weight);
+	    }
+	}
+    };
+
+    // Rotation functions
+    // Similar to the rotations for UV sampling coordinates
+    // R0/1/2/3 are the number of rotations CCW (called from rotate()
+    template<typename T>
+    void VecAccumTV_R0(float* dst, const T* val, float weight)
+    {
+	dst[0] += val[0] * weight;
+	dst[1] += val[1] * weight;
+    }
+    template<typename T>
+    void VecAccumTV_R1(float* dst, const T* val, float weight)
+    {
+	dst[0] -= val[1] * weight;
+	dst[1] += val[0] * weight;
+    }
+    template<typename T>
+    void VecAccumTV_R2(float* dst, const T* val, float weight)
+    {
+	dst[0] -= val[0] * weight;
+	dst[1] -= val[1] * weight;
+    }
+    template<typename T>
+    void VecAccumTV_R3(float* dst, const T* val, float weight)
+    {
+	dst[0] += val[1] * weight;
+	dst[1] -= val[0] * weight;
+    }
+    typedef void (*AccumRotFn)(float* dst, const float* src, float weight);
+    static AccumRotFn accumRotFunctions[4] = {
+	VecAccumTV_R0<float>, VecAccumTV_R1<float>,
+	VecAccumTV_R2<float>, VecAccumTV_R3<float>,
+    };
+
     // apply to 1..4 channels (unrolled channel loop) of packed data (nTxChan==nChan)
     template<class T, int nChan>
     void Apply(PtexSeparableKernel& k, float* result, void* data, int /*nChan*/, int /*nTxChan*/)
@@ -49,6 +130,7 @@ namespace {
 	float* kvp = k.kv;
 	T* p = (T*)data + (k.v * k.res.u() + k.u) * nChan;
 	T* pEnd = p + k.vw * rowlen;
+	AccumRotFn rot = accumRotFunctions[k.rot&3];
 	while (p != pEnd)
 	{
 	    float* kup = k.ku;
@@ -63,7 +145,7 @@ namespace {
 		p += nChan;
 	    }
 	    // result[i] += rowResult[i] * kv[v] for i in {0..n-1}
-	    PtexUtils::VecAccum<float,nChan>()(result, rowResult, *kvp++);
+	    VecAccumTV<float,nChan>()(result, rowResult, *kvp++, rot);
 	    p += rowskip;
 	}
     }
@@ -79,6 +161,7 @@ namespace {
 	float* kvp = k.kv;
 	T* p = (T*)data + (k.v * k.res.u() + k.u) * nTxChan;
 	T* pEnd = p + k.vw * rowlen;
+	AccumRotFn rot = accumRotFunctions[k.rot&3];
 	while (p != pEnd)
 	{
 	    float* kup = k.ku;
@@ -93,7 +176,7 @@ namespace {
 		p += nTxChan;
 	    }
 	    // result[i] += rowResult[i] * kv[v] for i in {0..n-1}
-	    PtexUtils::VecAccum<float,nChan>()(result, rowResult, *kvp++);
+	    VecAccumTV<float,nChan>()(result, rowResult, *kvp++, rot);
 	    p += rowskip;
 	}
     }
@@ -109,6 +192,7 @@ namespace {
 	float* kvp = k.kv;
 	T* p = (T*)data + (k.v * k.res.u() + k.u) * nTxChan;
 	T* pEnd = p + k.vw * rowlen;
+	AccumRotFn rot = accumRotFunctions[k.rot&3];
 	while (p != pEnd)
 	{
 	    float* kup = k.ku;
@@ -123,10 +207,42 @@ namespace {
 		p += nTxChan;
 	    }
 	    // result[i] += rowResult[i] * kv[v] for i in {0..n-1}
-	    PtexUtils::VecAccumN<float>()(result, rowResult, nChan, *kvp++);
+	    VecAccumNTV<float>()(result, rowResult, nChan, *kvp++, rot);
 	    p += rowskip;
 	}
     }
+
+    // apply const with consideration to rot
+    template<class T>
+    void ApplyConstNTV(float weight, float* dst, void* data, int nChan, int rot)
+    {
+	typedef void (*RotConstFn)(float* dst, const T* val, float weight);
+	RotConstFn rotFn;
+	switch (rot&3)
+	{
+	    default: rotFn = VecAccumTV_R0<T>; break;
+	    case 1: rotFn = VecAccumTV_R1<T>; break;
+	    case 2: rotFn = VecAccumTV_R2<T>; break;
+	    case 3: rotFn = VecAccumTV_R3<T>; break;
+	}
+	VecAccumNTV<T>()(dst, (T*) data, nChan, weight, rotFn);
+    }
+
+    template<class T, int nChan>
+    void ApplyConstTV(float weight, float* dst, void* data, int /*nChan*/, int rot)
+    {
+	typedef void (*RotConstFn)(float* dst, const T* val, float weight);
+	RotConstFn rotFn;
+	switch (rot&3)
+	{
+	    default: rotFn = VecAccumTV_R0<T>; break;
+	    case 1: rotFn = VecAccumTV_R1<T>; break;
+	    case 2: rotFn = VecAccumTV_R2<T>; break;
+	    case 3: rotFn = VecAccumTV_R3<T>; break;
+	}
+	VecAccumTV<T, nChan>()(dst, (T*) data, weight, rotFn);
+    }
+
 }
 
 
@@ -146,4 +262,14 @@ PtexSeparableKernel::applyFunctions[] = {
     ApplyS<uint8_t,2>, ApplyS<uint16_t,2>, ApplyS<PtexHalf,2>, ApplyS<float,2>,
     ApplyS<uint8_t,3>, ApplyS<uint16_t,3>, ApplyS<PtexHalf,3>, ApplyS<float,3>,
     ApplyS<uint8_t,4>, ApplyS<uint16_t,4>, ApplyS<PtexHalf,4>, ApplyS<float,4>,
+
+};
+
+PtexSeparableKernel::ApplyConstFn
+PtexSeparableKernel::applyConstFunctions[] = {
+    ApplyConstNTV<uint8_t>,  ApplyConstNTV<uint16_t>,  ApplyConstNTV<PtexHalf>,  ApplyConstNTV<float>,
+    ApplyConstTV<uint8_t,1>, ApplyConstTV<uint16_t,1>, ApplyConstTV<PtexHalf,1>, ApplyConstTV<float,1>,
+    ApplyConstTV<uint8_t,2>, ApplyConstTV<uint16_t,2>, ApplyConstTV<PtexHalf,2>, ApplyConstTV<float,2>,
+    ApplyConstTV<uint8_t,3>, ApplyConstTV<uint16_t,3>, ApplyConstTV<PtexHalf,3>, ApplyConstTV<float,3>,
+    ApplyConstTV<uint8_t,4>, ApplyConstTV<uint16_t,4>, ApplyConstTV<PtexHalf,4>, ApplyConstTV<float,4>,
 };

--- a/src/ptex/PtexUtils.cpp
+++ b/src/ptex/PtexUtils.cpp
@@ -68,6 +68,14 @@ const char* Ptex::BorderModeName(BorderMode m)
     return names[m];
 }
 
+const char* Ptex::EdgeFilterModeName(EdgeFilterMode m)
+{
+    static const char* names[] = { "none", "tanvec" };
+    if (m < 0 || m >= int(sizeof(names)/sizeof(const char*)))
+	return "(invalid edge filter mode)";
+    return names[m];
+}
+
 
 const char* Ptex::EdgeIdName(EdgeId eid)
 {

--- a/src/ptex/PtexWriter.cpp
+++ b/src/ptex/PtexWriter.cpp
@@ -760,6 +760,9 @@ PtexMainWriter::PtexMainWriter(const char* path, PtexTexture* tex,
 	// copy border modes
 	setBorderModes(tex->uBorderMode(), tex->vBorderMode());
 
+	// copy edge filter mode
+	setEdgeFilterMode(tex->edgeFilterMode());
+
 	// copy meta data from existing file
 	PtexPtr<PtexMetaData> meta ( _reader->getMetaData() );
 	writeMeta(meta);

--- a/src/ptex/PtexWriter.h
+++ b/src/ptex/PtexWriter.h
@@ -53,6 +53,10 @@ public:
 	_extheader.ubordermode = uBorderMode;
 	_extheader.vbordermode = vBorderMode;
     }
+    virtual void setEdgeFilterMode(Ptex::EdgeFilterMode edgeFilterMode)
+    {
+	    _extheader.edgefiltermode = edgeFilterMode;
+    }
     virtual void writeMeta(const char* key, const char* value);
     virtual void writeMeta(const char* key, const int8_t* value, int count);
     virtual void writeMeta(const char* key, const int16_t* value, int count);

--- a/src/ptex/Ptexture.h
+++ b/src/ptex/Ptexture.h
@@ -65,9 +65,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include "PtexInt.h"
 #include <ostream>
 
-#define PtexAPIVersion 2
+#define PtexAPIVersion 3
 #define PtexFileMajorVersion 1
-#define PtexFileMinorVersion 3
+#define PtexFileMinorVersion 4
 
 /** Common data structures and enums used throughout the API. */
 struct Ptex {
@@ -85,6 +85,12 @@ struct Ptex {
 	dt_uint16,		///< Unsigned, 16-bit integer.
 	dt_half,		///< Half-precision (16-bit) floating point.
 	dt_float		///< Single-precision (32-bit) floating point.
+    };
+
+    /** How to handle transformation across edges when filtering */
+    enum EdgeFilterMode {
+	efm_none,		///< Don't do anything with the values.
+	efm_tanvec		///< Values are vectors in tangent space; rotate values.
     };
 
     /** How to handle mesh border when filtering. */
@@ -121,6 +127,9 @@ struct Ptex {
 
     /** Look up name of given border mode. */
     PTEXAPI static const char* BorderModeName(BorderMode m);
+
+    /** Look up name of given edge filter mode. */
+    PTEXAPI static const char* EdgeFilterModeName(EdgeFilterMode m);
 
     /** Look up name of given edge ID. */
     PTEXAPI static const char* EdgeIdName(EdgeId eid);
@@ -475,6 +484,9 @@ class PtexTexture {
     /** Mode for filtering texture access beyond mesh border. */
     virtual Ptex::BorderMode vBorderMode() = 0;
 
+    /** Mode for filtering textures across edges. */
+    virtual Ptex::EdgeFilterMode edgeFilterMode() = 0;
+
     /** Index of alpha channel (if any).  One channel in the file can be flagged to be the alpha channel.
 	If no channel is acting as the alpha channel, -1 is returned.
 	See PtexWriter for more details.  */
@@ -794,6 +806,9 @@ class PtexWriter {
     
     /** Set border modes */
     virtual void setBorderModes(Ptex::BorderMode uBorderMode, Ptex::BorderMode vBorderMode) = 0;
+
+    /** Set edge filter mode */
+    virtual void setEdgeFilterMode(Ptex::EdgeFilterMode edgeFilterMode) = 0;
 
     /** Write a string as meta data.  Both the key and string params must be null-terminated strings. */
     virtual void writeMeta(const char* key, const char* string) = 0;


### PR DESCRIPTION
If the values stored in Ptex are vectors defined in tangent space of the face (from the ordered verticies; i.e using 0-1 and 0-3 as basis vectors), then filtering across edges does not work, as values across edges may be in a different space.

This modification allows a user to specify an EdgeFilterMode in a Ptex file to specify if the values are defined in this space or not. If they are, then the values are rotated during sampling, utilizing the UV sampling rotation to determine orientation.

This modification is only for PtexSeparableFilter, and PtexTriangleFilter is left untouched.