### PR TITLE
Cmake enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-install
+/build
+/install
 *.o
 *.so
 *.a

--- a/README
+++ b/README
@@ -20,11 +20,11 @@ libPtex.a  libPtex.so
 Building with cmake:
 mkdir build
 cd build
-cmake ../src
+cmake -DCMAKE_INSTALL_PREFIX=../install ../src
 make
 make test
 make install
 make doc
 
-Note: docs will be generated into local 'install' directory.
-(TODO: generate in build directory.)
+Note: docs will be generated in the 'build/doc' directory
+and installed as 'install/share/doc/ptex'.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 project(ptex)
 
-# enable testing for the project
+include(GNUInstallDirs)
 include(CTest)
-enable_testing()
-
 include(FindZLIB)
 include(FindThreads)
+
+enable_testing()
 
 include_directories(ptex)
 include_directories(${ZLIB_INCLUDE_DIR})

--- a/src/doc/.gitignore
+++ b/src/doc/.gitignore
@@ -1,0 +1,4 @@
+/apidocs
+/ptex
+/doxygen_log.txt
+/doxygen_sqlite3.db

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -1,13 +1,19 @@
 find_package ( Doxygen )
 
-file ( MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/../install/doc)
-
 if (DOXYGEN_FOUND)
-  set (generated_doc_location ${CMAKE_SOURCE_DIR}/../install/doc/ptex/)
-  set (doxyfile_location ${CMAKE_SOURCE_DIR}/doc/)
+  set (generated_doc_location ${CMAKE_CURRENT_BINARY_DIR}/doc)
+  set (doxyfile_location ${CMAKE_CURRENT_SOURCE_DIR} )
   set (perm OWNER_READ GROUP_READ WORLD_READ)
-  add_custom_target (doc
-      ${DOXYGEN_EXECUTABLE} ${doxyfile_location}/Doxyfile
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/doc
+  file ( READ ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile doxygen_configuration_file )
+  file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile ${doxygen_configuration_file} )
+  file ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile "OUTPUT_DIRECTORY = ${generated_doc_location}\n" )
+  file ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile "INPUT = ${CMAKE_SOURCE_DIR}/ptex ${CMAKE_CURRENT_SOURCE_DIR}\n" )
+  add_custom_target (doc ALL
+      ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+    )
+  install ( DIRECTORY
+    ${generated_doc_location}
+    DESTINATION
+    share
     )
 endif (DOXYGEN_FOUND)

--- a/src/doc/CMakeLists.txt
+++ b/src/doc/CMakeLists.txt
@@ -1,19 +1,22 @@
-find_package ( Doxygen )
-
+find_package(Doxygen)
 if (DOXYGEN_FOUND)
-  set (generated_doc_location ${CMAKE_CURRENT_BINARY_DIR}/doc)
-  set (doxyfile_location ${CMAKE_CURRENT_SOURCE_DIR} )
-  set (perm OWNER_READ GROUP_READ WORLD_READ)
-  file ( READ ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile doxygen_configuration_file )
-  file ( WRITE ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile ${doxygen_configuration_file} )
-  file ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile "OUTPUT_DIRECTORY = ${generated_doc_location}\n" )
-  file ( APPEND ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile "INPUT = ${CMAKE_SOURCE_DIR}/ptex ${CMAKE_CURRENT_SOURCE_DIR}\n" )
-  add_custom_target (doc ALL
-      ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-    )
-  install ( DIRECTORY
-    ${generated_doc_location}
-    DESTINATION
-    share
-    )
+
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/doxygen_log.txt
+        COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile >doxygen_log.txt
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        DEPENDS Doxyfile)
+    add_custom_target(doc ALL DEPENDS doxygen_log.txt)
+
+    # "make doxygen" forces doxygen to run
+    add_custom_target(
+        doxygen ${DOXYGEN_EXECUTABLE} Doxyfile >doxygen_log.txt
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        DEPENDS Doxyfile)
+
+    install(DIRECTORY ptex/ DESTINATION ${CMAKE_INSTALL_DOCDIR})
+
+    file(GLOB images "*.png")
+    install(FILES ${images} DESTINATION ${CMAKE_INSTALL_DOCDIR})
+
 endif (DOXYGEN_FOUND)

--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NUMBER         =
 # If a relative path is entered, it will be relative to the location 
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../../install/doc
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 
 # 4096 sub-directories (in 2 levels) under the output directory of each output 
@@ -999,7 +999,7 @@ SEARCH_INCLUDES        = YES
 # contain include files that are not input files but should be processed by 
 # the preprocessor.
 
-INCLUDE_PATH           = 
+INCLUDE_PATH           = .
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard 
 # patterns (like *.h and *.hpp) to filter out the header-files in the 

--- a/src/doc/Doxyfile
+++ b/src/doc/Doxyfile
@@ -154,13 +154,6 @@ QT_AUTOBRIEF           = NO
 
 MULTILINE_CPP_IS_BRIEF = NO
 
-# If the DETAILS_AT_TOP tag is set to YES then Doxygen 
-# will output the detailed description near the top, like JavaDoc.
-# If set to NO, the detailed description appears after the member 
-# documentation.
-
-DETAILS_AT_TOP         = NO
-
 # If the INHERIT_DOCS tag is set to YES (the default) then an undocumented 
 # member inherits the documentation from any documented member that it 
 # re-implements.
@@ -393,12 +386,6 @@ MAX_INITIALIZER_LINES  = 30
 # list will mention the files that were used to generate the documentation.
 
 SHOW_USED_FILES        = YES
-
-# If the sources in your project are distributed over multiple directories 
-# then setting the SHOW_DIRECTORIES tag to YES will show the directory hierarchy 
-# in the documentation. The default is NO.
-
-SHOW_DIRECTORIES       = NO
 
 # The FILE_VERSION_FILTER tag can be used to specify a program or script that 
 # doxygen should invoke to get the current version for each file (typically from the 
@@ -694,12 +681,6 @@ HTML_FOOTER            =
 
 HTML_STYLESHEET        = 
 
-# If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes, 
-# files or namespaces will be aligned in HTML using tables. If set to 
-# NO a bullet list will be used.
-
-HTML_ALIGN_MEMBERS     = YES
-
 # If the GENERATE_HTMLHELP tag is set to YES, additional index files 
 # will be generated that can be used as input for tools like the 
 # Microsoft HTML help workshop to generate a compressed HTML help file (.chm) 
@@ -933,18 +914,6 @@ GENERATE_XML           = NO
 # put in front of it. If left blank `xml' will be used as the default path.
 
 XML_OUTPUT             = xml
-
-# The XML_SCHEMA tag can be used to specify an XML schema, 
-# which can be used by a validating XML parser to check the 
-# syntax of the XML files.
-
-XML_SCHEMA             = 
-
-# The XML_DTD tag can be used to specify an XML DTD, 
-# which can be used by a validating XML parser to check the 
-# syntax of the XML files.
-
-XML_DTD                = 
 
 # If the XML_PROGRAMLISTING tag is set to YES Doxygen will 
 # dump the program listings (including syntax highlighting 

--- a/src/doc/Doxyfile_API_only
+++ b/src/doc/Doxyfile_API_only
@@ -38,7 +38,7 @@ PROJECT_NUMBER         =
 # If a relative path is entered, it will be relative to the location 
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = ../..
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create 
 # 4096 sub-directories (in 2 levels) under the output directory of each output 

--- a/src/doc/Makefile
+++ b/src/doc/Makefile
@@ -3,11 +3,13 @@
 
 all: doc
 
-INSTALLDIR = ../../install/doc/ptex
+INSTALLDIR = ../../install/share/doc/ptex
 
 doc:
 	mkdir -p $(INSTALLDIR)
 	doxygen Doxyfile
+	rsync -vrP ptex/ $(INSTALLDIR)/
+	install -m 644 *.png $(INSTALLDIR)
 
 clean:
 	rm -rf $(INSTALLDIR)

--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (WIN32)
-  add_definitions ( /DPTEX_EXPORTS )
+    add_definitions(/DPTEX_EXPORTS)
 endif (WIN32)
 
 set(SRCS
@@ -22,24 +22,11 @@ set_target_properties(Ptex_dynamic PROPERTIES OUTPUT_NAME Ptex)
 
 target_link_libraries(Ptex_dynamic ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
 
-if ( PTEX_LIB_DIR )
-  SET ( INSTALL_LIBRARY_DIR ${PTEX_LIB_DIR} )
-else ()
-  SET ( INSTALL_LIBRARY_DIR lib )
-endif ()
+install(TARGETS Ptex_static Ptex_dynamic DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-# installation
-install ( TARGETS
-  Ptex_static
-  Ptex_dynamic
-  DESTINATION
-  ${INSTALL_LIBRARY_DIR}
-  )
-install ( FILES
-  PtexHalf.h
-  PtexInt.h
-  Ptexture.h
-  PtexUtils.h
-  DESTINATION
-  include
-  )
+install(FILES
+        PtexHalf.h
+        PtexInt.h
+        Ptexture.h
+        PtexUtils.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -21,3 +21,25 @@ add_library(Ptex_dynamic SHARED ${SRCS})
 set_target_properties(Ptex_dynamic PROPERTIES OUTPUT_NAME Ptex)
 
 target_link_libraries(Ptex_dynamic ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+
+if ( PTEX_LIB_DIR )
+  SET ( INSTALL_LIBRARY_DIR ${PTEX_LIB_DIR} )
+else ()
+  SET ( INSTALL_LIBRARY_DIR lib )
+endif ()
+
+# installation
+install ( TARGETS
+  Ptex_static
+  Ptex_dynamic
+  DESTINATION
+  ${INSTALL_LIBRARY_DIR}
+  )
+install ( FILES
+  PtexHalf.h
+  PtexInt.h
+  Ptexture.h
+  PtexUtils.h
+  DESTINATION
+  include
+  )

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -26,7 +26,3 @@ add_test(NAME wtest COMMAND $<TARGET_FILE:wtest>)
 add_compare_test(rtest)
 add_compare_test(ftest)
 add_test(NAME halftest COMMAND $<TARGET_FILE:halftest>)
-
-
-
-

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,10 +1,10 @@
 # build version string from git query
-execute_process(COMMAND git rev-list --max-count=1 HEAD
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
+execute_process(COMMAND git rev-parse HEAD
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                 OUTPUT_VARIABLE PTEX_SHA
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND git describe ${PTEX_SHA}
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
+                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
                 OUTPUT_VARIABLE PTEX_VER
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,11 +1,20 @@
 # build version string from git query
 execute_process(COMMAND git rev-list --max-count=1 HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
                 OUTPUT_VARIABLE PTEX_SHA
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND git describe ${PTEX_SHA}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/..
                 OUTPUT_VARIABLE PTEX_VER
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 add_executable(ptxinfo ptxinfo.cpp)
 add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)")
 target_link_libraries(ptxinfo Ptex_dynamic)
+
+# installation
+install ( TARGETS
+  ptxinfo
+  DESTINATION
+  bin
+  )

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -12,9 +12,4 @@ add_executable(ptxinfo ptxinfo.cpp)
 add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)")
 target_link_libraries(ptxinfo Ptex_dynamic)
 
-# installation
-install ( TARGETS
-  ptxinfo
-  DESTINATION
-  bin
-  )
+install(TARGETS ptxinfo DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Use GNUInstallDirs to provide a consistent way to override paths.
Use CMAKE_INSTALL_FOO variables when installing targets.
Do not rebuild the "doc" target needlessly.
Rework the doxygen setup to build in-place.
