### PR TITLE
Fix Win10/MSVC2015 build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,19 @@ if (NOT WIN32)
     set(CMAKE_CXX_FLAGS "-std=c++98 -Wall -Wextra -pedantic")
 endif ()
 
+if(MSVC)
+    add_definitions(
+
+        #warning C4800: 'BOOL': forcing value to bool 'true' or 'false' (performance warning)
+        /wd4800 
+
+        #warning C4244: 'argument': conversion from 'double' to 'float', possible loss of data
+        /wd4244 
+
+        /D_CRT_SECURE_NO_WARNINGS
+    )
+endif()
+
 if (${PRMAN_15_COMPATIBLE_PTEX})
     add_definitions(-DPTEX_NO_LARGE_METADATA_BLOCKS)
 endif ()

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_definitions(-DPTEX_STATIC)
+
 add_executable(wtest wtest.cpp)
 target_link_libraries(wtest Ptex_dynamic)
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -9,7 +9,7 @@ execute_process(COMMAND git describe ${PTEX_SHA}
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 add_executable(ptxinfo ptxinfo.cpp)
-add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)")
+add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)" -DPTEX_STATIC)
 target_link_libraries(ptxinfo Ptex_dynamic)
 
 install(TARGETS ptxinfo DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
- tests & utils need PTEX_STATIC to be defined or we get link errors on static functions
- disabled some warnings (recommending those be fixed in the code)

I was only able to test this with Win10 / MSVC 2015 : this should be tested against other OS / compilers before merging (although i don't expect any problems...)
