### PR TITLE
utils: link ptxinfo statically

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -10,6 +10,6 @@ execute_process(COMMAND git describe ${PTEX_SHA}
 
 add_executable(ptxinfo ptxinfo.cpp)
 add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)" -DPTEX_STATIC)
-target_link_libraries(ptxinfo Ptex_dynamic)
+target_link_libraries(ptxinfo Ptex_static z ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS ptxinfo DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Allow Ptex's command-line tools to be installed sans libPtex.so by
linking ptxinfo statically.

Signed-off-by: David Aguilar <davvid@gmail.com>