### PR TITLE
Remove hardcoded reference to libz

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -10,6 +10,6 @@ execute_process(COMMAND git describe ${PTEX_SHA}
 
 add_executable(ptxinfo ptxinfo.cpp)
 add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)" -DPTEX_STATIC)
-target_link_libraries(ptxinfo Ptex_static z ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(ptxinfo Ptex_static ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 install(TARGETS ptxinfo DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Pretty straightforward, it seems someone was in a rush and didn't 
replace the library reference with the appropriate variable.