### PR TITLE
Add control of building static/dynamic libs in CMake files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 project(ptex)
 
+option(PTEX_BUILD_STATIC_LIBS "Enable building Ptex static libraries" ON)
+option(PTEX_BUILD_SHARED_LIBS "Enable building Ptex shared libraries" ON)
+
 include(GNUInstallDirs)
 include(CTest)
 include(FindZLIB)

--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -14,15 +14,19 @@ set(SRCS
     PtexUtils.cpp
     PtexWriter.cpp)
 
-add_library(Ptex_static STATIC ${SRCS})
-set_target_properties(Ptex_static PROPERTIES OUTPUT_NAME Ptex)
+if(PTEX_BUILD_STATIC_LIBS)
+  add_library(Ptex_static STATIC ${SRCS})
+  set_target_properties(Ptex_static PROPERTIES OUTPUT_NAME Ptex)
+  target_link_libraries(Ptex_static ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+  install(TARGETS Ptex_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
-add_library(Ptex_dynamic SHARED ${SRCS})
-set_target_properties(Ptex_dynamic PROPERTIES OUTPUT_NAME Ptex)
-
-target_link_libraries(Ptex_dynamic ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
-
-install(TARGETS Ptex_static Ptex_dynamic DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if(PTEX_BUILD_SHARED_LIBS)
+  add_library(Ptex_dynamic SHARED ${SRCS})
+  set_target_properties(Ptex_dynamic PROPERTIES OUTPUT_NAME Ptex)
+  target_link_libraries(Ptex_dynamic ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+  install(TARGETS Ptex_dynamic DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
 install(FILES
         PtexHalf.h

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,16 +1,21 @@
 add_definitions(-DPTEX_STATIC)
 
 add_executable(wtest wtest.cpp)
-target_link_libraries(wtest Ptex_dynamic)
-
 add_executable(rtest rtest.cpp)
-target_link_libraries(rtest Ptex_dynamic)
-
 add_executable(ftest ftest.cpp)
-target_link_libraries(ftest Ptex_dynamic)
-
 add_executable(halftest halftest.cpp)
-target_link_libraries(halftest Ptex_dynamic)
+
+if(PTEX_BUILD_SHARED_LIBS)
+  target_link_libraries(wtest Ptex_dynamic)
+  target_link_libraries(rtest Ptex_dynamic)
+  target_link_libraries(ftest Ptex_dynamic)
+  target_link_libraries(halftest Ptex_dynamic)
+elseif(PTEX_BUILD_STATIC_LIBS)
+  target_link_libraries(wtest Ptex_static)
+  target_link_libraries(rtest Ptex_static)
+  target_link_libraries(ftest Ptex_static)
+  target_link_libraries(halftest Ptex_static)
+endif()
 
 # create a function to add tests that compare output
 # file results

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -10,6 +10,11 @@ execute_process(COMMAND git describe ${PTEX_SHA}
 
 add_executable(ptxinfo ptxinfo.cpp)
 add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)" -DPTEX_STATIC)
-target_link_libraries(ptxinfo Ptex_static ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+
+if(PTEX_BUILD_SHARED_LIBS)
+  target_link_libraries(ptxinfo Ptex_dynamic ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+elseif(PTEX_BUILD_STATIC_LIBS)
+  target_link_libraries(ptxinfo Ptex_static ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 install(TARGETS ptxinfo DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
By default, both are built, just like it is currently. However,
there are now PTEX_BUILD_{SHARED,STATIC}_LIBS options can be disabled
independently.

Context: I'm building ptex on a system that for various reasons only has a
static version of zlib in turn, I'm getting the error:

[ 94%] Linking CXX shared library libPtex.so
/usr/bin/ld: ../../../zlib/libz.a(deflate.o): relocation R_X86_64_PC32 against symbol `_length_code' can not be used when making a shared object; recompile with -fPIC

Hence, I'd like to be able to disable building the shared libs since I
don't need them anyway...