### PR TITLE
build: modernize cmake usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8)
-project(ptex)
+project(Ptex)
 
 option(PTEX_BUILD_STATIC_LIBS "Enable building Ptex static libraries" ON)
 option(PTEX_BUILD_SHARED_LIBS "Enable building Ptex shared libraries" ON)
@@ -82,9 +82,9 @@ if (${PRMAN_15_COMPATIBLE_PTEX})
 endif ()
 
 include_directories(src/ptex)
-include_directories(${ZLIB_INCLUDE_DIR})
 
 add_subdirectory(src/ptex)
 add_subdirectory(src/utils)
 add_subdirectory(src/tests)
 add_subdirectory(src/doc)
+add_subdirectory(src/build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ option(PTEX_BUILD_STATIC_LIBS "Enable building Ptex static libraries" ON)
 option(PTEX_BUILD_SHARED_LIBS "Enable building Ptex shared libraries" ON)
 option(PRMAN_15_COMPATIBLE_PTEX "Enable PRMan 15 compatibility" OFF)
 
+set(CMAKE_INSTALL_MESSAGE LAZY) # Silence "Up-to-date:" install messages
+
 if (NOT DEFINED PTEX_SHA)
     # Query git for current commit ID
     execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,40 @@
 cmake_minimum_required(VERSION 2.8)
 project(ptex)
 
+if (NOT DEFINED PTEX_SHA)
+    # Query git for current commit ID
+    execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        OUTPUT_VARIABLE PTEX_SHA
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif ()
+
+if (NOT DEFINED PTEX_VER)
+    # Get the version string from a "version" file or from git
+    if (EXISTS "${PROJECT_SOURCE_DIR}/version")
+        file(STRINGS "${PROJECT_SOURCE_DIR}/version" PTEX_VER)
+    else  ()
+        execute_process(
+            COMMAND git describe --first-parent --always HEAD
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+            OUTPUT_VARIABLE PTEX_VER
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif ()
+endif ()
+
+# Transform PTEX_VER into PTEX_MAJOR_VERSION and PTEX_MINOR_VERSION
+string(REPLACE "v" "" PTEX_VER_STRIPPED ${PTEX_VER})  # strip leading "v"
+string(REPLACE "." ";" PTEX_VER_LIST ${PTEX_VER_STRIPPED})
+list(LENGTH PTEX_VER_LIST PTEX_VER_LENGTH)
+if (${PTEX_VER_LENGTH} LESS 2)
+    message(FATAL_ERROR "Could not determine the Ptex library version")
+endif ()
+
+# The version variables are used to generate PtexVersion.h
+list(GET PTEX_VER_LIST 0 PTEX_MAJOR_VERSION)
+list(GET PTEX_VER_LIST 1 PTEX_MINOR_VERSION)
+
 option(PTEX_BUILD_STATIC_LIBS "Enable building Ptex static libraries" ON)
 option(PTEX_BUILD_SHARED_LIBS "Enable building Ptex shared libraries" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8)
 project(ptex)
 
+option(PTEX_BUILD_STATIC_LIBS "Enable building Ptex static libraries" ON)
+option(PTEX_BUILD_SHARED_LIBS "Enable building Ptex shared libraries" ON)
+option(PRMAN_15_COMPATIBLE_PTEX "Enable PRMan 15 compatibility" OFF)
+
 if (NOT DEFINED PTEX_SHA)
     # Query git for current commit ID
     execute_process(
@@ -34,9 +38,6 @@ endif ()
 # The version variables are used to generate PtexVersion.h
 list(GET PTEX_VER_LIST 0 PTEX_MAJOR_VERSION)
 list(GET PTEX_VER_LIST 1 PTEX_MINOR_VERSION)
-
-option(PTEX_BUILD_STATIC_LIBS "Enable building Ptex static libraries" ON)
-option(PTEX_BUILD_SHARED_LIBS "Enable building Ptex shared libraries" ON)
 
 include(GNUInstallDirs)
 include(CTest)

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ default:: test
 
 test:: all
 
+clean:: uninstall
+
 configure = $(build)/cmake.conf
 $(configure):
 	$(QUIET)mkdir -p $(build)
@@ -63,3 +65,11 @@ cmake:
 all clean doc install test:: $(configure)
 	+$(QUIET)cmake --build $(build) --target $@ $(FLAGS)
 
+install::
+	$(QUIET)cp $(build)/install_manifest.txt $(build).manifest.txt
+
+uninstall: $(configure)
+	$(QUIET)touch $(build).manifest.txt
+	$(QUIET)xargs rm -f <$(build).manifest.txt
+	$(QUIET)xargs dirname <$(build).manifest.txt 2>/dev/null | \
+	sort -u -r | xargs rmdir -p >/dev/null 2>&1 || true

--- a/Makefile
+++ b/Makefile
@@ -1,58 +1,61 @@
 #!/usr/bin/env make
-SH ?= sh
-uname_S := $(shell $(SH) -c 'uname -s || echo kernel')
-uname_R := $(shell $(SH) -c 'uname -r | cut -d- -f1 || echo release')
-uname_M := $(shell $(SH) -c 'uname -m || echo machine')
+# prefix=<path> specifies the installation prefix (ex: /usr/local)
+# DESTDIR=<path> specifies the temporary staging directory (ex: /tmp/stage)
+# V=1 or VERBOSE=1 enables verbose builds
+# NO_NINJA=1 disables autodetection and use of ninja
+# PRMAN_15_COMPATIBLE_PTEX=1 enables compatibility with PRman 15
+# FLAVOR={opt,debug,profile} sets CMAKE_BUILD_TYPE using short aliases
+# BUILD_TYPE={Release,Debug,RelWithDebInfo} sets CMAKE_BUILD_TYPE directly
+
+FLAGS =
 FLAVOR ?= optimize
-platform_dir ?= $(uname_S)-$(uname_R)-$(uname_M)-$(FLAVOR)
-cmake_dir ?= $(CURDIR)/build/$(platform_dir)
-cmake_done ?= $(cmake_dir)/cmake.done
+uname_S := $(shell sh -c 'uname -s || echo kernel')
+uname_R := $(shell sh -c '(uname -r || echo release) | cut -d- -f1')
+uname_M := $(shell sh -c 'uname -m || echo machine')
+platform ?= $(uname_S)-$(uname_R)-$(uname_M)-$(FLAVOR)
+build = build/$(platform)
+# Installation prefix
+prefix = $(CURDIR)/$(platform)
+CMAKE_FLAGS = -DCMAKE_INSTALL_PREFIX=$(prefix)
 
-prefix ?= $(CURDIR)/$(platform_dir)
-#DESTDIR =
+ifdef V
+    VERBOSE = 1
+endif
+ifndef VERBOSE
+    QUIET = @
+endif
 
-CMAKE_FLAGS ?= -DCMAKE_INSTALL_PREFIX=$(prefix)
-
+# Ninja auto-detection
+NO_NINJA := $(shell sh -c '(type ninja >/dev/null && echo 0) || echo 1')
+ifeq ($(NO_NINJA),1)
+    CMAKE_FLAGS += -G "Unix Makefiles"
+    FLAGS += -- --no-print-directory
+else
+    CMAKE_FLAGS += -G Ninja
+    FLAGS += $(shell sh -c '\
+        VERBOSE=$(VERBOSE) ./src/build/ninja-flags.sh $(MAKEFLAGS)')
+endif
 ifdef PRMAN_15_COMPATIBLE_PTEX
     CMAKE_FLAGS += -DPRMAN_15_COMPATIBLE_PTEX:BOOL=TRUE
 endif
-
 ifdef TOOLCHAIN
     CMAKE_FLAGS += -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN)
 endif
-
 ifdef BUILD_TYPE
     CMAKE_FLAGS += -DCMAKE_BUILD_TYPE=$(BUILD_TYPE)
 endif
 
-# make V=1 shortcut for VERBOSE=1
-ifdef V
-    VERBOSE=1
-    export VERBOSE
-endif
+# Targets
+default:: test
 
-all::
+test:: all
 
-$(cmake_done):
-	mkdir -p $(cmake_dir)
-	cd $(cmake_dir) && cmake $(CMAKE_FLAGS) ../..
-	touch $@
+configure = $(build)/cmake.conf
+$(configure):
+	$(QUIET)mkdir -p $(build)
+	$(QUIET)cd $(build) && cmake $(CMAKE_FLAGS) $(CURDIR)
+	$(QUIET)touch $@
 
-cmake: $(cmake_done)
-.PHONY: cmake
+all clean doc install test:: $(configure)
+	+$(QUIET)cmake --build $(build) --target $@ $(FLAGS)
 
-all:: cmake
-	$(MAKE) -C $(cmake_dir) --no-print-directory $(MAKEARGS) all
-	$(MAKE) -C $(cmake_dir) --no-print-directory $(MAKEARGS) test
-
-clean: cmake
-	$(MAKE) -C $(cmake_dir) --no-print-directory $(MAKEARGS) clean
-
-doc: cmake
-	$(MAKE) -C $(cmake_dir) --no-print-directory $(MAKEARGS) doc
-
-install: cmake
-	$(MAKE) -C $(cmake_dir) --no-print-directory $(MAKEARGS) install
-
-test: cmake
-	$(MAKE) -C $(cmake_dir) --no-print-directory $(MAKEARGS) test

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ $(configure):
 	$(QUIET)cd $(build) && cmake $(CMAKE_FLAGS) $(CURDIR)
 	$(QUIET)touch $@
 
+cmake:
+	$(QUIET)mkdir -p $(build)
+	$(QUIET)cd $(build) && cmake $(CMAKE_FLAGS) $(CURDIR)
+
 all clean doc install test:: $(configure)
 	+$(QUIET)cmake --build $(build) --target $@ $(FLAGS)
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,1 +1,0 @@
-/config.mak

--- a/src/build/CMakeLists.txt
+++ b/src/build/CMakeLists.txt
@@ -1,0 +1,19 @@
+include(CMakePackageConfigHelpers)
+
+set(CMAKE_DIR "share/cmake/Ptex")
+
+write_basic_package_version_file("ptex-version.cmake"
+    VERSION "${PTEX_MAJOR_VERSION}.${PTEX_MINOR_VERSION}"
+    COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file(
+    "ptex-config.cmake" "ptex-config.cmake"
+    INSTALL_DESTINATION "${CMAKE_DIR}" PATH_VARS
+    CMAKE_INSTALL_PREFIX CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/ptex-config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/ptex-version.cmake"
+    DESTINATION "${CMAKE_DIR}" COMPONENT "devel")
+
+install(EXPORT Ptex NAMESPACE Ptex::
+    FILE "ptex-exports.cmake" DESTINATION "${CMAKE_DIR}" COMPONENT "devel")

--- a/src/build/ninja-flags.sh
+++ b/src/build/ninja-flags.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# make >= 4.2 includes -j<num> in $(MAKEFLAGS).
+# make sets VERBOSE when calling this script.
+ninja_flags () {
+    for flag in "$@"
+    do
+        num_jobs=$(expr "z$flag" : 'z-j\([0-9]\+\)')
+        test -n "$num_jobs" && break
+    done
+    test -n "$num_jobs" && opt_jobs=" -j $num_jobs"
+    test -n "$VERBOSE" && opt_verbose=" -v"
+
+    if test -n "$opt_jobs" || test -n "$opt_verbose"
+    then
+        printf -- '--%s%s' "$opt_jobs" "$opt_verbose"
+    fi
+}
+
+ninja_flags "$@"

--- a/src/build/ptex-config.cmake
+++ b/src/build/ptex-config.cmake
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/ptex-version.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/ptex-exports.cmake")
+
+set_and_check(Ptex_DIR @PACKAGE_CMAKE_INSTALL_PREFIX@)
+set_and_check(Ptex_LIBRARY_DIRS @PACKAGE_CMAKE_INSTALL_LIBDIR@)
+set_and_check(Ptex_INCLUDE_DIRS @PACKAGE_CMAKE_INSTALL_INCLUDEDIR@)
+
+set(Ptex_FOUND TRUE)

--- a/src/ptex/.gitignore
+++ b/src/ptex/.gitignore
@@ -1,0 +1,1 @@
+/PtexVersion.h

--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -2,6 +2,9 @@ if (WIN32)
     add_definitions(/DPTEX_EXPORTS)
 endif (WIN32)
 
+configure_file(PtexVersion.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/PtexVersion.h @ONLY)
+
 set(SRCS
     PtexCache.cpp
     PtexFilters.cpp

--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -18,17 +18,33 @@ set(SRCS
     PtexWriter.cpp)
 
 if(PTEX_BUILD_STATIC_LIBS)
-  add_library(Ptex_static STATIC ${SRCS})
-  set_target_properties(Ptex_static PROPERTIES OUTPUT_NAME Ptex)
-  target_link_libraries(Ptex_static ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
-  install(TARGETS Ptex_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    add_library(Ptex_static STATIC ${SRCS})
+    set_target_properties(Ptex_static PROPERTIES OUTPUT_NAME Ptex)
+    target_include_directories(Ptex_static
+    PUBLIC
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+        $<INSTALL_INTERFACE:${ZLIB_INCLUDE_DIR}>
+        $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIR}>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(Ptex_static
+        PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+    install(TARGETS Ptex_static EXPORT Ptex DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 if(PTEX_BUILD_SHARED_LIBS)
-  add_library(Ptex_dynamic SHARED ${SRCS})
-  set_target_properties(Ptex_dynamic PROPERTIES OUTPUT_NAME Ptex)
-  target_link_libraries(Ptex_dynamic ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
-  install(TARGETS Ptex_dynamic DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    add_library(Ptex_dynamic SHARED ${SRCS})
+    set_target_properties(Ptex_dynamic PROPERTIES OUTPUT_NAME Ptex)
+    target_include_directories(Ptex_dynamic
+        PUBLIC
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+            $<INSTALL_INTERFACE:${ZLIB_INCLUDE_DIR}>
+            $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIR}>
+        PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR})
+    target_link_libraries(Ptex_dynamic
+        PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+    install(TARGETS Ptex_dynamic EXPORT Ptex DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 install(FILES
@@ -37,4 +53,5 @@ install(FILES
         Ptexture.h
         PtexUtils.h
         PtexVersion.h
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        COMPONENT devel)

--- a/src/ptex/PtexVersion.h.in
+++ b/src/ptex/PtexVersion.h.in
@@ -39,8 +39,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #define PtexAPIVersion 4
 #define PtexFileMajorVersion 1
 #define PtexFileMinorVersion 4
-#define PtexLibraryMajorVersion 2
-#define PtexLibraryMinorVersion 2
+#define PtexLibraryMajorVersion @PTEX_MAJOR_VERSION@
+#define PtexLibraryMinorVersion @PTEX_MINOR_VERSION@
 
 #define PTEX_NAMESPACE Ptex
 #ifdef PTEX_VENDOR

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -24,12 +24,12 @@ function(add_compare_test test_name)
     COMMAND ${CMAKE_COMMAND}
     -DOUT=${CMAKE_CURRENT_BINARY_DIR}/${test_name}.out
     -DDATA=${CMAKE_CURRENT_SOURCE_DIR}/${test_name}ok.dat
-    -DCMD=$<TARGET_FILE:${test_name}>
+    -DCMD=${CMAKE_CURRENT_BINARY_DIR}/${test_name}
     -P ${CMAKE_CURRENT_SOURCE_DIR}/compare_test.cmake)
 endfunction(add_compare_test)
 
 # add all the tests
-add_test(NAME wtest COMMAND $<TARGET_FILE:wtest>)
+add_test(NAME wtest COMMAND wtest)
 add_compare_test(rtest)
 add_compare_test(ftest)
-add_test(NAME halftest COMMAND $<TARGET_FILE:halftest>)
+add_test(NAME halftest COMMAND halftest)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,13 +1,3 @@
-# build version string from git query
-execute_process(COMMAND git rev-parse HEAD
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                OUTPUT_VARIABLE PTEX_SHA
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND git describe ${PTEX_SHA}
-                WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-                OUTPUT_VARIABLE PTEX_VER
-                OUTPUT_STRIP_TRAILING_WHITESPACE)
-
 add_executable(ptxinfo ptxinfo.cpp)
 add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)" -DPTEX_STATIC)
 


### PR DESCRIPTION
Export Ptex's targets so that downstream products can use Ptex with minimal configuration.
Generate PtexVersion.h at build time so that we don't have to hard-code the library version.
Use the ninja build system when available.