### PR TITLE
Fix mismatch between windows and other platforms for atomic add and subtract macros.

### DIFF
--- a/src/ptex/PtexPlatform.h
+++ b/src/ptex/PtexPlatform.h
@@ -164,10 +164,10 @@ private:
 
 #ifdef WINDOWS
     #define ATOMIC_ALIGNED __declspec(align(8))
-    #define ATOMIC_ADD32(x,y) InterlockedExchangeAdd((volatile long*)(x),(long)(y))
-    #define ATOMIC_ADD64(x,y) InterlockedExchangeAdd64((volatile long long*)(x),(long long)(y))
-    #define ATOMIC_SUB32(x,y) InterlockedExchangeAdd((volatile long*)(x),-((long)(y)))
-    #define ATOMIC_SUB64(x,y) InterlockedExchangeAdd64((volatile long long*)(x),-((long long)(y)))
+    #define ATOMIC_ADD32(x,y) InterlockedExchangeAdd((volatile long*)(x),(long)(y)) + y
+    #define ATOMIC_ADD64(x,y) InterlockedExchangeAdd64((volatile long long*)(x),(long long)(y)) + y
+    #define ATOMIC_SUB32(x,y) InterlockedExchangeAdd((volatile long*)(x),-((long)(y))) - y
+    #define ATOMIC_SUB64(x,y) InterlockedExchangeAdd64((volatile long long*)(x),-((long long)(y))) - y
     #define MEM_FENCE()       MemoryBarrier()
     #define BOOL_CMPXCH32(x,y,z) (InterlockedCompareExchange((volatile long*)(x),(long)(z),(long)(y))   == (y))
     #define BOOL_CMPXCH64(x,y,z) (InterlockedCompareExchange64((volatile long long*)(x),(long long)(z),(long long)(y)) == (y))


### PR DESCRIPTION
Windows InterlockedExchangeAdd functions return the initial value of the addend rather than the new value like __sync_add_and_fetch. I updated the platform atomic add/subtract macros so the new value is returned on each platform.