### PR TITLE
cmake: find zlib using PkgConfig

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ else ()
     set(CMAKE_CXX_STANDARD 98)
 endif ()
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS ON)
 set(CMAKE_INSTALL_MESSAGE LAZY) # Silence "Up-to-date:" install messages
 
 if (NOT DEFINED PTEX_SHA)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,8 +58,11 @@ list(GET PTEX_VER_LIST 1 PTEX_MINOR_VERSION)
 
 include(GNUInstallDirs)
 include(CTest)
-include(FindZLIB)
 include(FindThreads)
+
+# Use pkg-config to create a PkgConfig::Ptex_ZLIB imported target
+find_package(PkgConfig REQUIRED)
+pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)
 
 enable_testing()
 

--- a/src/build/ptex-config.cmake
+++ b/src/build/ptex-config.cmake
@@ -3,6 +3,10 @@
 include("${CMAKE_CURRENT_LIST_DIR}/ptex-version.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/ptex-exports.cmake")
 
+# Provide PkgConfig::ZLIB to downstream dependents
+find_package(PkgConfig REQUIRED)
+pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)
+
 set_and_check(Ptex_DIR @PACKAGE_CMAKE_INSTALL_PREFIX@)
 set_and_check(Ptex_LIBRARY_DIRS @PACKAGE_CMAKE_INSTALL_LIBDIR@)
 set_and_check(Ptex_INCLUDE_DIRS @PACKAGE_CMAKE_INSTALL_INCLUDEDIR@)

--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -23,12 +23,10 @@ if(PTEX_BUILD_STATIC_LIBS)
     target_include_directories(Ptex_static
     PUBLIC
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-        $<INSTALL_INTERFACE:${ZLIB_INCLUDE_DIR}>
-        $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIR}>
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(Ptex_static
-        PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+        PUBLIC ${CMAKE_THREAD_LIBS_INIT} PkgConfig::Ptex_ZLIB)
     install(TARGETS Ptex_static EXPORT Ptex DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
@@ -38,12 +36,10 @@ if(PTEX_BUILD_SHARED_LIBS)
     target_include_directories(Ptex_dynamic
         PUBLIC
             $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-            $<INSTALL_INTERFACE:${ZLIB_INCLUDE_DIR}>
-            $<BUILD_INTERFACE:${ZLIB_INCLUDE_DIR}>
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(Ptex_dynamic
-        PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES})
+        PUBLIC ${CMAKE_THREAD_LIBS_INIT} PkgConfig::Ptex_ZLIB)
     install(TARGETS Ptex_dynamic EXPORT Ptex DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -2,9 +2,9 @@ add_executable(ptxinfo ptxinfo.cpp)
 add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)" -DPTEX_STATIC)
 
 if(PTEX_BUILD_SHARED_LIBS)
-  target_link_libraries(ptxinfo Ptex_dynamic ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(ptxinfo Ptex_dynamic PkgConfig::Ptex_ZLIB ${CMAKE_THREAD_LIBS_INIT})
 elseif(PTEX_BUILD_STATIC_LIBS)
-  target_link_libraries(ptxinfo Ptex_static ${ZLIB_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    target_link_libraries(ptxinfo Ptex_static PkgConfig::Ptex_ZLIB ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 install(TARGETS ptxinfo DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Build against zlib using an imported target that can be reused by downstream dependents.