### PR TITLE
tools+tests: prefer using static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,13 @@ if (MSVC)
     )
 endif()
 
+# Set the default Ptex library to use for tools and tests.
+if (PTEX_BUILD_STATIC_LIBS)
+    set(PTEX_LIBRARY Ptex_static)
+else()
+    set(PTEX_LIBRARY Ptex_dynamic)
+endif()
+
 if (${PRMAN_15_COMPATIBLE_PTEX})
     add_definitions(-DPTEX_NO_LARGE_METADATA_BLOCKS)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,22 @@ else ()
 endif ()
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS ON)
-set(CMAKE_INSTALL_MESSAGE LAZY) # Silence "Up-to-date:" install messages
+set(CMAKE_INSTALL_MESSAGE LAZY)
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+include(GNUInstallDirs)
+
+include(CTest)
+enable_testing()
+
+# Setup platform-specific threading flags.
+find_package(Threads REQUIRED)
+
+# Use pkg-config to create a PkgConfig::Ptex_ZLIB imported target
+find_package(PkgConfig REQUIRED)
+pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)
+
 
 if (NOT DEFINED PTEX_SHA)
     # Query git for current commit ID
@@ -59,16 +74,6 @@ endif ()
 # The version variables are used to generate PtexVersion.h
 list(GET PTEX_VER_LIST 0 PTEX_MAJOR_VERSION)
 list(GET PTEX_VER_LIST 1 PTEX_MINOR_VERSION)
-
-include(GNUInstallDirs)
-include(CTest)
-include(FindThreads)
-
-# Use pkg-config to create a PkgConfig::Ptex_ZLIB imported target
-find_package(PkgConfig REQUIRED)
-pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)
-
-enable_testing()
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     # Detect the build type from the $FLAVOR environment variable

--- a/src/build/ptex-config.cmake
+++ b/src/build/ptex-config.cmake
@@ -3,6 +3,10 @@
 include("${CMAKE_CURRENT_LIST_DIR}/ptex-version.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/ptex-exports.cmake")
 
+set(CMAKE_THREAD_PREFER_PTHREAD ON)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 # Provide PkgConfig::ZLIB to downstream dependents
 find_package(PkgConfig REQUIRED)
 pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)

--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -26,7 +26,7 @@ if(PTEX_BUILD_STATIC_LIBS)
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(Ptex_static
-        PUBLIC ${CMAKE_THREAD_LIBS_INIT} PkgConfig::Ptex_ZLIB)
+        PUBLIC Threads::Threads PkgConfig::Ptex_ZLIB)
     install(TARGETS Ptex_static EXPORT Ptex DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
@@ -39,7 +39,7 @@ if(PTEX_BUILD_SHARED_LIBS)
         PRIVATE
             ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(Ptex_dynamic
-        PUBLIC ${CMAKE_THREAD_LIBS_INIT} PkgConfig::Ptex_ZLIB)
+        PUBLIC Threads::Threads PkgConfig::Ptex_ZLIB)
     install(TARGETS Ptex_dynamic EXPORT Ptex DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,21 +1,15 @@
-add_definitions(-DPTEX_STATIC)
-
+if(PTEX_BUILD_STATIC_LIBS)
+    add_definitions(-DPTEX_STATIC)
+endif()
 add_executable(wtest wtest.cpp)
 add_executable(rtest rtest.cpp)
 add_executable(ftest ftest.cpp)
 add_executable(halftest halftest.cpp)
 
-if(PTEX_BUILD_SHARED_LIBS)
-  target_link_libraries(wtest Ptex_dynamic)
-  target_link_libraries(rtest Ptex_dynamic)
-  target_link_libraries(ftest Ptex_dynamic)
-  target_link_libraries(halftest Ptex_dynamic)
-elseif(PTEX_BUILD_STATIC_LIBS)
-  target_link_libraries(wtest Ptex_static)
-  target_link_libraries(rtest Ptex_static)
-  target_link_libraries(ftest Ptex_static)
-  target_link_libraries(halftest Ptex_static)
-endif()
+target_link_libraries(wtest ${PTEX_LIBRARY})
+target_link_libraries(rtest ${PTEX_LIBRARY})
+target_link_libraries(ftest ${PTEX_LIBRARY})
+target_link_libraries(halftest ${PTEX_LIBRARY})
 
 # create a function to add tests that compare output
 # file results

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,10 +1,9 @@
 add_executable(ptxinfo ptxinfo.cpp)
-add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)" -DPTEX_STATIC)
-
-if(PTEX_BUILD_SHARED_LIBS)
-    target_link_libraries(ptxinfo Ptex_dynamic PkgConfig::Ptex_ZLIB ${CMAKE_THREAD_LIBS_INIT})
-elseif(PTEX_BUILD_STATIC_LIBS)
-    target_link_libraries(ptxinfo Ptex_static PkgConfig::Ptex_ZLIB ${CMAKE_THREAD_LIBS_INIT})
+add_definitions(-DPTEX_VER="${PTEX_VER} \(${PTEX_SHA}\)")
+if (PTEX_BUILD_STATIC_LIBS)
+    add_definitions(-DPTEX_STATIC)
 endif()
+
+target_link_libraries(ptxinfo ${PTEX_LIBRARY} PkgConfig::Ptex_ZLIB)
 
 install(TARGETS ptxinfo DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Use the imported Threads::Threads cmake target to setup threading flags.
Prefer using static libraries when both are enabled.

Closes #44