### PR TITLE
Include documentation build dependencies in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ The Makefile uses cmake under the hood.
 This will build, install to a local 'install' directory, and
 run regression tests.
 
+Documentation is only built if the following dependencies are installed:
+
+- [Doxygen](http://www.doxygen.nl/)
+- [Graphviz](https://graphviz.org/)
+
 
 ## Installation Contents
 


### PR DESCRIPTION
If the documentation dependencies don't exist when cmake is run, the build will succeed but documentation will not be built and `make doc` target is not available. Added documentation to README.md to point this out.