### PR TITLE
Include <unistd.h> for macOS in order to build on macOS 11.0

### DIFF
--- a/src/ptex/PtexPlatform.h
+++ b/src/ptex/PtexPlatform.h
@@ -69,6 +69,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #ifdef __APPLE__
 #include <os/lock.h>
 #include <sys/types.h>
+#include <unistd.h>
 #endif
 #endif
 


### PR DESCRIPTION
This header needs to be added in order for PtexWriter.cpp to pick up
unlink() on macOS 11.0.