### PR TITLE
Fix for static library build on Windows

### DIFF
--- a/src/ptex/PtexExports.h
+++ b/src/ptex/PtexExports.h
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #       if defined(PTEX_EXPORTS)
 #           define PTEXAPI __declspec(dllexport)
 #       else
-#           define PTEXAPI __declspec(dllimport)
+#           define PTEXAPI
 #       endif
 #   elif defined(PTEX_COMPILER_CLANG) || defined(PTEX_COMPILER_GCC) \
         || defined(PTEX_COMPILER_ICC)


### PR DESCRIPTION
I wasn't able to build Ptex as a static library without this change (I got tons of errors about conflicting dllexport flags). I'm not sure if this interferes with @davvid's recent symbol export visibility work though.