### PR TITLE
build: restore DLL import declarations while retaining static lib usage

### DIFF
--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SRCS
 if(PTEX_BUILD_STATIC_LIBS)
     add_library(Ptex_static STATIC ${SRCS})
     set_target_properties(Ptex_static PROPERTIES OUTPUT_NAME Ptex)
+    target_compile_definitions(Ptex_static PUBLIC PTEX_STATIC)
     target_include_directories(Ptex_static
     PUBLIC
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/src/ptex/PtexExports.h
+++ b/src/ptex/PtexExports.h
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #       if defined(PTEX_EXPORTS)
 #           define PTEXAPI __attribute__((visibility("default")))
 #       else
-#           define PTEXAPI
+#           define PTEXAPI ____declspec(dllimport)
 #       endif
 #   else
 #       define PTEXAPI


### PR DESCRIPTION
Make sure that we #define PTEX_STATIC when building the ptex static library.
This allows the PtexExports.h header file to avoid use of the DLL import/export
declarations when using static libraries.