### PR TITLE
Use find_package() for zlib instead of pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,7 @@ enable_testing()
 # Setup platform-specific threading flags.
 find_package(Threads REQUIRED)
 
-# Use pkg-config to create a PkgConfig::Ptex_ZLIB imported target
 find_package(ZLIB REQUIRED)
-
 
 if (NOT DEFINED PTEX_SHA)
     # Query git for current commit ID

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,7 @@ enable_testing()
 find_package(Threads REQUIRED)
 
 # Use pkg-config to create a PkgConfig::Ptex_ZLIB imported target
-find_package(PkgConfig REQUIRED)
-pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)
+find_package(ZLIB REQUIRED)
 
 
 if (NOT DEFINED PTEX_SHA)

--- a/src/build/ptex-config.cmake
+++ b/src/build/ptex-config.cmake
@@ -8,9 +8,7 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_dependency(Threads REQUIRED)
 
-# Provide PkgConfig::ZLIB to downstream dependents
-find_dependency(PkgConfig REQUIRED)
-pkg_checK_modules(Ptex_ZLIB REQUIRED zlib IMPORTED_TARGET)
+find_package(ZLIB REQUIRED)
 
 set_and_check(Ptex_DIR @PACKAGE_CMAKE_INSTALL_PREFIX@)
 set_and_check(Ptex_LIBRARY_DIRS @PACKAGE_CMAKE_INSTALL_LIBDIR@)

--- a/src/ptex/CMakeLists.txt
+++ b/src/ptex/CMakeLists.txt
@@ -23,7 +23,7 @@ if(PTEX_BUILD_STATIC_LIBS)
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR})
     target_link_libraries(Ptex_static
-        PUBLIC Threads::Threads PkgConfig::Ptex_ZLIB)
+        PUBLIC Threads::Threads ZLIB::ZLIB)
     install(TARGETS Ptex_static EXPORT Ptex DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 
@@ -39,7 +39,7 @@ if(PTEX_BUILD_SHARED_LIBS)
             ${CMAKE_CURRENT_SOURCE_DIR})
     target_compile_definitions(Ptex_dynamic PRIVATE PTEX_EXPORTS)
     target_link_libraries(Ptex_dynamic
-        PUBLIC Threads::Threads PkgConfig::Ptex_ZLIB)
+        PUBLIC Threads::Threads ZLIB::ZLIB)
     install(TARGETS Ptex_dynamic EXPORT Ptex DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,6 +4,6 @@ if (PTEX_BUILD_STATIC_LIBS)
     add_definitions(-DPTEX_STATIC)
 endif()
 
-target_link_libraries(ptxinfo ${PTEX_LIBRARY} PkgConfig::Ptex_ZLIB)
+target_link_libraries(ptxinfo ${PTEX_LIBRARY} ZLIB::ZLIB)
 
 install(TARGETS ptxinfo DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
pkg-config is not available on windows (and finding, building and installing it is tricky). The native FindZLIB.cmake works just fine and is used by mahy other projects (e.g. tiff, raw, png, openexr, openjpeg, oiio).
