### PR TITLE
Small fix to compile with Clang 14 under Windows

### DIFF
--- a/src/ptex/PtexInt.h
+++ b/src/ptex/PtexInt.h
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 #if defined(_WIN32) || defined(_WINDOWS) || defined(_MSC_VER)
 
-#if defined(_MSC_VER) && _MSC_VER >= 1600
+#if defined(_MSC_VER) && _MSC_VER >= 1600 || defined(__MINGW64__)
 #include <stdint.h>
 #else
 typedef __int8            int8_t;


### PR DESCRIPTION
This small fix allow the use of `stdint.h` when compiled using Clang 14 under Windows 10. The previous code only considered the MSVC case.
Tested using the LLVM & MinGW toolchain for Windows from here: https://github.com/mstorsjo/llvm-mingw
Cheers..