### PR TITLE
Addressing Issue 72 to fix builds for FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(Ptex)
 
 option(PTEX_BUILD_STATIC_LIBS "Enable building Ptex static libraries" ON)
 option(PTEX_BUILD_SHARED_LIBS "Enable building Ptex shared libraries" ON)
+option(PTEX_BUILD_DOCS "Enable building Ptex documentation (require Doxygen)" OFF)
 option(PRMAN_15_COMPATIBLE_PTEX "Enable PRMan 15 compatibility" OFF)
 
 # The C++ standard can set either through the environment or by specifyign
@@ -114,6 +115,8 @@ include_directories(src/ptex)
 add_subdirectory(src/ptex)
 add_subdirectory(src/utils)
 add_subdirectory(src/tests)
-add_subdirectory(src/doc)
+if (PTEX_BUILD_DOCS)
+    add_subdirectory(src/doc)
+endif ()
 add_subdirectory(src/build)
 

--- a/src/ptex/PtexPlatform.h
+++ b/src/ptex/PtexPlatform.h
@@ -70,7 +70,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 // linux/unix/posix
 #include <stdlib.h>
-#include <alloca.h>
+#if !defined(__FreeBSD__)
+    #include <alloca.h>
+#endif
 #include <string.h>
 #include <pthread.h>
 

--- a/src/ptex/PtexWriter.cpp
+++ b/src/ptex/PtexWriter.cpp
@@ -66,6 +66,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <algorithm>
 #include <iostream>
 #include <sstream>
+#if defined(__FreeBSD__)
+    #include <unistd.h>
+    #include <stddef.h>
+#endif
 
 #include "Ptexture.h"
 #include "PtexUtils.h"


### PR DESCRIPTION
**Summary**

This PR addresses the issue #72, which is based on the solution provided in [this commit](https://cgit.freebsd.org/ports/commit/?id=5c793405d0e9f0aa05553a2888d6e31b1a17edb1).

This is because `alloca.h` does not exists in FreeBSD, instead it is in `stdlib.h`. Reference: [https://bugs.freedesktop.org/show_bug.cgi?id=15536](https://bugs.freedesktop.org/show_bug.cgi?id=15536)