### PR TITLE
PtexReader.cpp: validate mesh_type in header on open

### DIFF
--- a/src/ptex/PtexReader.cpp
+++ b/src/ptex/PtexReader.cpp
@@ -169,6 +169,14 @@ bool PtexReader::open(const char* pathArg, Ptex::String& error)
         closeFP();
         return 0;
     }
+    if (!(_header.meshtype == mt_triangle || _header.meshtype == mt_quad)) {
+        std::stringstream s;
+        s << "Invalid mesh type (" << _header.meshtype << "): " << pathArg;
+	error = s.str();
+	_ok = 0;
+	closeFP();
+	return 0;
+    }
     _pixelsize = _header.pixelSize();
     _errorPixel.resize(_pixelsize);
 


### PR DESCRIPTION
This validates the meshtype field of the header on `open`.
This field is currently already checked in the writer in `checkFormat`, and in the `meshTypeName` function.

As a part of working on the rust bindings which have stricter `enum` value domains than c++ enums, it came up
that while we currently cannot write an invalid meshtype, It appears there is potential that we could read one most likely through a corrupted file.

I don't have a corrupted file handy to test this though.